### PR TITLE
Fixes endless loading

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,0 +1,13 @@
+-- Variable to check if native has already been run
+local Ran = false
+
+-- Wait until client is loaded into the map
+AddEventHandler("playerSpawned", function ()
+	-- If not already ran
+	if not Ran then
+		-- Close loading screen resource
+		ShutdownLoadingScreenNui()
+		-- Set as ran
+		Ran = true
+	end
+end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,5 +1,6 @@
 fx_version 'cerulean'
 game 'gta5'
+client_script 'client.lua'
 
 files {
 	'dist/index.html',
@@ -8,9 +9,7 @@ files {
 	'dist/assets/*'
 }
 
-loadscreen {
-	'dist/index.html'
-}
+loadscreen 'dist/index.html'
 
 loadscreen_cursor 'yes'
 loadscreen_manual_shutdown 'yes'


### PR DESCRIPTION
Great loading screen! Here's a working client.lua to fix the endless loading issue. Alternatively deleting "loadscreen_manual_shutdown 'yes'" in fxmanifest would work, but this looks nicer.